### PR TITLE
LIBFCREPO-661. Update Tomcat library version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <tomcat.version>7.0.52</tomcat.version>
+    <tomcat.version>7.0.88</tomcat.version>
   </properties>
   <build>
   <plugins>


### PR DESCRIPTION
Use 7.0.88 to match production version of Tomcat.

https://issues.umd.edu/browse/LIBFCREPO-661